### PR TITLE
Add circle controlled by keyboard input in Siv3D

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -3,19 +3,19 @@
 void Main()
 {
 	// 背景の色を設定する | Set the background color
-	Scene::SetBackground(ColorF{ 0.6, 0.8, 0.7 });
+	s3d::Scene::SetBackground(s3d::ColorF{ 0.6, 0.8, 0.7 });
 
 	// 画像ファイルからテクスチャを作成する | Create a texture from an image file
-	const Texture texture{ U"example/windmill.png" };
+	const s3d::Texture texture{ U"example/windmill.png" };
 
 	// 絵文字からテクスチャを作成する | Create a texture from an emoji
-	const Texture emoji{ U"🦖"_emoji };
+	const s3d::Texture emoji{ U"🦖"_emoji };
 
 	// 太文字のフォントを作成する | Create a bold font with MSDF method
-	const Font font{ FontMethod::MSDF, 48, Typeface::Bold };
+	const s3d::Font font{ s3d::FontMethod::MSDF, 48, s3d::Typeface::Bold };
 
 	// テキストに含まれる絵文字のためのフォントを作成し、font に追加する | Create a font for emojis in text and add it to font as a fallback
-	const Font emojiFont{ 48, Typeface::ColorEmoji };
+	const s3d::Font emojiFont{ 48, s3d::Typeface::ColorEmoji };
 	font.addFallback(emojiFont);
 
 	// ボタンを押した回数 | Number of button presses
@@ -33,64 +33,85 @@ void Main()
 	// プレイヤーが右を向いているか | Whether player is facing right
 	bool isPlayerFacingRight = true;
 
-	while (System::Update())
+	s3d::Vec2 playerPosition{ 400, 300 };
+
+	while (s3d::System::Update())
 	{
+		if (s3d::KeyW.pressed())
+		{
+			playerPosition.y -= 5.0;
+		}
+		if (s3d::KeyS.pressed())
+		{
+			playerPosition.y += 5.0;
+		}
+		if (s3d::KeyA.pressed())
+		{
+			playerPosition.x -= 5.0;
+		}
+		if (s3d::KeyD.pressed())
+		{
+			playerPosition.x += 5.0;
+		}
+
 		// テクスチャを描く | Draw the texture
 		texture.draw(20, 20);
 
 		// テキストを描く | Draw text
-		font(U"Hello, Siv3D!🎮").draw(64, Vec2{ 20, 340 }, ColorF{ 0.2, 0.4, 0.8 });
+		font(U"Hello, Siv3D!🎮").draw(64, s3d::Vec2{ 20, 340 }, s3d::ColorF{ 0.2, 0.4, 0.8 });
 
 		// 指定した範囲内にテキストを描く | Draw text within a specified area
 		font(U"Siv3D (シブスリーディー) は、ゲームやアプリを楽しく簡単な C++ コードで開発できるフレームワークです。")
-			.draw(18, Rect{ 20, 430, 480, 200 }, Palette::Black);
+			.draw(18, s3d::Rect{ 20, 430, 480, 200 }, s3d::Palette::Black);
 
 		// 長方形を描く | Draw a rectangle
-		Rect{ 540, 20, 80, 80 }.draw();
+		s3d::Rect{ 540, 20, 80, 80 }.draw();
 
 		// 角丸長方形を描く | Draw a rounded rectangle
-		RoundRect{ 680, 20, 80, 200, 20 }.draw(ColorF{ 0.0, 0.4, 0.6 });
+		s3d::RoundRect{ 680, 20, 80, 200, 20 }.draw(s3d::ColorF{ 0.0, 0.4, 0.6 });
 
 		// 円を描く | Draw a circle
-		Circle{ 580, 180, 40 }.draw(Palette::Seagreen);
+		s3d::Circle{ 580, 180, 40 }.draw(s3d::Palette::Seagreen);
 
 		// 矢印を描く | Draw an arrow
-		Line{ 540, 330, 760, 260 }.drawArrow(8, SizeF{ 20, 20 }, ColorF{ 0.4 });
+		s3d::Line{ 540, 330, 760, 260 }.drawArrow(8, s3d::SizeF{ 20, 20 }, s3d::ColorF{ 0.4 });
 
 		// 半透明の円を描く | Draw a semi-transparent circle
-		Circle{ Cursor::Pos(), 40 }.draw(ColorF{ 1.0, 0.0, 0.0, 0.5 });
+		s3d::Circle{ s3d::Cursor::Pos(), 40 }.draw(s3d::ColorF{ 1.0, 0.0, 0.0, 0.5 });
 
 		// ボタン | Button
-		if (SimpleGUI::Button(U"count: {}"_fmt(count), Vec2{ 520, 370 }, 120, (checked == false)))
+		if (s3d::SimpleGUI::Button(U"count: {}"_fmt(count), s3d::Vec2{ 520, 370 }, 120, (checked == false)))
 		{
 			// カウントを増やす | Increase the count
 			++count;
 		}
 
 		// チェックボックス | Checkbox
-		SimpleGUI::CheckBox(checked, U"Lock \U000F033E", Vec2{ 660, 370 }, 120);
+		s3d::SimpleGUI::CheckBox(checked, U"Lock \U000F033E", s3d::Vec2{ 660, 370 }, 120);
 
 		// スライダー | Slider
-		SimpleGUI::Slider(U"speed: {:.1f}"_fmt(speed), speed, 100, 400, Vec2{ 520, 420 }, 140, 120);
+		s3d::SimpleGUI::Slider(U"speed: {:.1f}"_fmt(speed), speed, 100, 400, s3d::Vec2{ 520, 420 }, 140, 120);
 
 		// 左キーが押されていたら | If left key is pressed
-		if (KeyLeft.pressed())
+		if (s3d::KeyLeft.pressed())
 		{
 			// プレイヤーが左に移動する | Player moves left
-			playerPosX = Max((playerPosX - speed * Scene::DeltaTime()), 60.0);
+			playerPosX = Max((playerPosX - speed * s3d::Scene::DeltaTime()), 60.0);
 			isPlayerFacingRight = false;
 		}
 
 		// 右キーが押されていたら | If right key is pressed
-		if (KeyRight.pressed())
+		if (s3d::KeyRight.pressed())
 		{
 			// プレイヤーが右に移動する | Player moves right
-			playerPosX = Min((playerPosX + speed * Scene::DeltaTime()), 740.0);
+			playerPosX = Min((playerPosX + speed * s3d::Scene::DeltaTime()), 740.0);
 			isPlayerFacingRight = true;
 		}
 
 		// プレイヤーを描く | Draw the player
 		emoji.scaled(0.75).mirrored(isPlayerFacingRight).drawAt(playerPosX, 540);
+
+		s3d::Circle(playerPosition, 30).draw(s3d::Palette::Orange);
 	}
 }
 


### PR DESCRIPTION
This commit implements the following features:
- Initializes a player position vector `s3d::Vec2 playerPosition`.
- Handles W, A, S, D key presses in the main loop to update `playerPosition`.
  - W moves the circle up.
  - A moves the circle left.
  - S moves the circle down.
  - D moves the circle right.
- Draws an orange circle with a radius of 30 at `playerPosition` in each frame.
- Ensures all Siv3D library calls use the explicit `s3d::` namespace.

The program allows you to control an orange circle on the screen using the W, A, S, and D keys. All code is contained within the `Main.cpp` file and its `Main()` function, adhering to Siv3D v0.6.16 practices.